### PR TITLE
Fix resource view url links

### DIFF
--- a/ckanext/featuredviews/templates/package/snippets/resource_views_list.html
+++ b/ckanext/featuredviews/templates/package/snippets/resource_views_list.html
@@ -3,14 +3,17 @@
 {% set snippet_type = 'asset' if ckan_29_or_higher else 'resource' %}
 {% snippet 'featuredviews/snippets/featuredviews_' ~ snippet_type ~ '.html', name='featured/featured_js' %}
 
-{% set resource_read_route = 'resource.read' if ckan_29_or_higher else 'resource_read' %}
-
 {% set views_created = views or resource_preview %}
 {% if views_created %}
   <ul class="nav nav-tabs {{ extra_class }}" {{ extra_attributes }}>
     {% if resource_preview %}
       <li{% if not view_id %} class="active"{% endif %}>
-        <a href="{{ h.url_for(resource_read_route, id=pkg.name, resource_id=resource.id) }}" >
+        {% if ckan_29_or_higher %}
+          {% set resource_read_url = h.url_for('resource.read', id=pkg.name, resource_id=resource.id) %}
+        {% else %}
+          {% set resource_read_url = h.url_for(controller='package', action='resource_read', id=pkg.name, resource_id=resource.id) %}
+        {% endif %}
+        <a href="{{ resource_read_url }}" >
           <i class="icon-eye-open fa fa-eye-open"></i>
           {{ _("Resource Preview") }}
         </a>

--- a/ckanext/featuredviews/templates/package/snippets/resource_views_list_item_featured.html
+++ b/ckanext/featuredviews/templates/package/snippets/resource_views_list_item_featured.html
@@ -1,18 +1,25 @@
 {% set ckan_29_or_higher = h.version(h.ckan_version()) > h.version('2.9') %}
 
-{% if is_edit %}
-  {% set named_route = 'resource.edit_view' if ckan_29_or_higher else 'edit_view' %}
+{% if ckan_29_or_higher %}
+  {% set action = 'resource.edit_view' if is_edit else 'resource.read' %}
+  {% if current_filters %}
+    {% set url = h.url_for(action, id=pkg.name,
+                           resource_id=view.resource_id, view_id=view.id,
+                           filters=current_filters) %}
+  {% else %}
+    {% set url = h.url_for(action, id=pkg.name,
+                           resource_id=view.resource_id, view_id=view.id) %}
+  {% endif %}
 {% else %}
-  {% set named_route = 'resource.read' if ckan_29_or_higher else 'resource_read' %}
-{% endif %}
-
-{% if current_filters %}
-  {% set url = h.url_for(named_route, id=pkg.name,
-                         resource_id=view.resource_id, view_id=view.id,
-                         filters=current_filters) %}
-{% else %}
-  {% set url = h.url_for(named_route, id=pkg.name,
-                         resource_id=view.resource_id, view_id=view.id) %}
+  {% set action = 'edit_view' if is_edit else 'resource_read' %}
+  {% if current_filters %}
+    {% set url = h.url_for(controller='package', action=action, id=pkg.name,
+                           resource_id=view.resource_id, view_id=view.id,
+                           filters=current_filters) %}
+  {% else %}
+    {% set url = h.url_for(controller='package', action=action, id=pkg.name,
+                           resource_id=view.resource_id, view_id=view.id) %}
+  {% endif %}
 {% endif %}
 
 <li {% if is_selected %}class="active view_item"{% endif %} data-id="{{ view.id }}">


### PR DESCRIPTION
## Description
This PR fixes the links to resource views.
On CKAN 2.7 the `resource_read` action should be used with the `package` controller in the `url_for` function.